### PR TITLE
Rename privacyUrl to policyUrl

### DIFF
--- a/resources/lang/en/texts.php
+++ b/resources/lang/en/texts.php
@@ -16,5 +16,5 @@ return [
     'settings_close' => 'Close',
     'settings_save' => 'Save',
     'settings_title' => 'Cookie settings',
-    'settings_text' => 'Our website keeps three levels of cookies. You can adjust your preferences at any time. If you want more information about what cookies are and which cookies we collect, please read our <a href=":privacyUrl">cookie policy</a>.',
+    'settings_text' => 'Our website keeps three levels of cookies. You can adjust your preferences at any time. If you want more information about what cookies are and which cookies we collect, please read our <a href=":policyUrl">cookie policy</a>.',
 ];


### PR DESCRIPTION
In resources/lang/en/texts.php privacyUrl variable must be named policyUrl