### PR TITLE
Fix accept all behaviour with custom COOKIE_VALUE_BOTH value

### DIFF
--- a/resources/js/cookie-consent.js
+++ b/resources/js/cookie-consent.js
@@ -63,7 +63,7 @@ function initialize() {
 
     addEventListener('click', '.js-lcc-accept', function () {
 
-        updateCookie('true');
+        updateCookie(COOKIE_VALUE_BOTH);
         hideModal(modalSettings, true);
         hideModal(modalAlert);
     });


### PR DESCRIPTION
Although the package config allows you to set 'cookie_value_both' to a custom value (default is 'true'), this value is not used when a user selects 'Accept All Cookies' - because the script uses a hardcoded 'true' value.