### PR TITLE
Feature/filament nav item

### DIFF
--- a/config/cookie-consent.php
+++ b/config/cookie-consent.php
@@ -1,12 +1,14 @@
 <?php
 
+use Filament\View\PanelsRenderHook;
+
 return [
     /**
      * Theme to use for the cookie consent popup.
      * Available options: 'default', 'filament'.
      */
     'theme' => 'default',
-    'disable_filament_nav_hook' => false,
+    'filament-nav-item-render-hook' => PanelsRenderHook::USER_MENU_PROFILE_AFTER,
     'cookie_key' => '__cookie_consent',
     'cookie_value_analytics' => '2',
     'cookie_value_marketing' => '3',

--- a/config/cookie-consent.php
+++ b/config/cookie-consent.php
@@ -6,6 +6,7 @@ return [
      * Available options: 'default', 'filament'.
      */
     'theme' => 'default',
+    'disable_filament_nav_hook' => false,
     'cookie_key' => '__cookie_consent',
     'cookie_value_analytics' => '2',
     'cookie_value_marketing' => '3',

--- a/readme.md
+++ b/readme.md
@@ -202,6 +202,13 @@ return [
      * Available options: 'default', 'filament'.
      */
     'theme' => 'default',
+    /**
+     * When using the filament theme we register 
+     * a navigation item in the sidebar that will
+     * open the cookie settings popup. Use this
+     * option to disable that.
+     */
+    'disable_filament_nav_hook' => false,
     'cookie_key' => '__cookie_consent',
     'cookie_value_analytics' => '2',
     'cookie_value_marketing' => '3',

--- a/resources/js/cookie-consent-filament.js
+++ b/resources/js/cookie-consent-filament.js
@@ -57,16 +57,16 @@ document.addEventListener('alpine:init', () => {
         },
         // Helper functions
         openCookieConsentModal() {
-            this.$dispatch('open-modal', { id: 'cookie-consent-modal' });
+            this.$dispatch('open-modal', { id: this.COOKIE_CONSENT_MODAL_ID });
         },
         closeCookieConsentModal() {
-            this.$dispatch('close-modal', { id: 'cookie-consent-modal' });
+            this.$dispatch('close-modal', { id: this.COOKIE_CONSENT_MODAL_ID });
         },
         openCookieSettingsModal() {
-            this.$dispatch('open-modal', { id: 'cookie-consent-settings-modal' });
+            this.$dispatch('open-modal', { id: this.COOKIE_CONSENT_SETTINGS_MODAL_ID });
         },
         closeCookieSettingsModal() {
-            this.$dispatch('close-modal', { id: 'cookie-consent-settings-modal' });
+            this.$dispatch('close-modal', { id: this.COOKIE_CONSENT_SETTINGS_MODAL_ID });
         },
         initialize() {
             const ignoredPathsArray = this.IGNORED_PATHS

--- a/resources/js/util/modals.js
+++ b/resources/js/util/modals.js
@@ -1,8 +1,6 @@
 import { isHidden, showElement, hideElement, getSiblings } from './dom';
 
 export function showModal(modal, ignoreBackdrop = false) {
-    $dispatch('open-modal', { id: 'cookie-consent-modal' });
-
     //  Make all sibling elements inert (not focusable)
     getSiblings(modal, ':not(.js-lcc-backdrop)').forEach((sibling) => {
         sibling.inert = true;

--- a/resources/views/filament-nav-item.blade.php
+++ b/resources/views/filament-nav-item.blade.php
@@ -1,0 +1,31 @@
+<ul class="fi-sidebar-nav-groups">
+    <li>
+        <ul class="fi-sidebar-group-items">
+            <li class="fi-sidebar-item fi-sidebar-item-has-url">
+                <a
+                    @click="$dispatch('open-modal', { id: 'cookie-consent-settings-modal' })"
+                    href="#"
+                    class="js-lcc-settings-toggle fi-sidebar-item-btn"
+                >
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        class="fi-icon fi-size-lg fi-sidebar-item-icon"
+                        fill="currentColor"
+                        data-slot="icon"
+                        viewBox="0 0 24 24"
+                    >
+                        <path
+                            d="M20.87 10.5C20.6 10 20 10 20 10H18V9C18 8 17 8 17 8H15V7C15 6 14 6 14 6H13V4C13 3 12 3 12 3C7.03 3 3 7.03 3 12C3 16.97 7.03 21 12 21C16.97 21 21 16.97 21 12C21 11.5 20.96 11 20.87 10.5M11.32 18.96C12 18.82 12.5 18.22 12.5 17.5C12.5 16.67 11.83 16 11 16S9.5 16.67 9.5 17.5C9.5 18 9.76 18.47 10.16 18.74C7.54 18.04 5.5 15.81 5.09 13.12C5 12.61 5 12.11 5 11.62C5.07 12.39 5.71 13 6.5 13C7.33 13 8 12.33 8 11.5S7.33 10 6.5 10C5.82 10 5.25 10.46 5.07 11.08C5.47 8 7.91 5.5 11 5.07V6.5C11 7.33 11.67 8 12.5 8H13V8.5C13 9.33 13.67 10 14.5 10H16V10.5C16 11.33 16.67 12 17.5 12H19C19 16.08 15.5 19.36 11.32 18.96M9.5 9C8.67 9 8 8.33 8 7.5S8.67 6 9.5 6 11 6.67 11 7.5 10.33 9 9.5 9M13 12.5C13 13.33 12.33 14 11.5 14S10 13.33 10 12.5 10.67 11 11.5 11 13 11.67 13 12.5M18 14.5C18 15.33 17.33 16 16.5 16S15 15.33 15 14.5 15.67 13 16.5 13 18 13.67 18 14.5Z"
+                        />
+                    </svg>
+
+                    <span
+                        class="fi-sidebar-item-label flex-1 truncate text-sm font-medium text-gray-700 dark:text-gray-200"
+                    >
+                        @lang('cookie-consent::texts.alert_settings')
+                    </span>
+                </a>
+            </li>
+        </ul>
+    </li>
+</ul>

--- a/resources/views/filament-nav-item.blade.php
+++ b/resources/views/filament-nav-item.blade.php
@@ -3,7 +3,7 @@
         <ul class="fi-sidebar-group-items">
             <li class="fi-sidebar-item fi-sidebar-item-has-url">
                 <a
-                    @click="$dispatch('open-modal', { id: 'cookie-consent-settings-modal' })"
+                    @click="$dispatch('open-modal', { id: '{{ \Statikbe\CookieConsent\CookieConsentServiceProvider::COOKIE_CONSENT_SETTINGS_MODAL_ID }}' })"
                     href="#"
                     class="js-lcc-settings-toggle fi-sidebar-item-btn"
                 >

--- a/resources/views/filament-nav-item.blade.php
+++ b/resources/views/filament-nav-item.blade.php
@@ -1,31 +1,19 @@
-<ul class="fi-sidebar-nav-groups">
-    <li>
-        <ul class="fi-sidebar-group-items">
-            <li class="fi-sidebar-item fi-sidebar-item-has-url">
-                <a
-                    @click="$dispatch('open-modal', { id: '{{ \Statikbe\CookieConsent\CookieConsentServiceProvider::COOKIE_CONSENT_SETTINGS_MODAL_ID }}' })"
-                    href="#"
-                    class="js-lcc-settings-toggle fi-sidebar-item-btn"
-                >
-                    <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        class="fi-icon fi-size-lg fi-sidebar-item-icon"
-                        fill="currentColor"
-                        data-slot="icon"
-                        viewBox="0 0 24 24"
-                    >
-                        <path
-                            d="M20.87 10.5C20.6 10 20 10 20 10H18V9C18 8 17 8 17 8H15V7C15 6 14 6 14 6H13V4C13 3 12 3 12 3C7.03 3 3 7.03 3 12C3 16.97 7.03 21 12 21C16.97 21 21 16.97 21 12C21 11.5 20.96 11 20.87 10.5M11.32 18.96C12 18.82 12.5 18.22 12.5 17.5C12.5 16.67 11.83 16 11 16S9.5 16.67 9.5 17.5C9.5 18 9.76 18.47 10.16 18.74C7.54 18.04 5.5 15.81 5.09 13.12C5 12.61 5 12.11 5 11.62C5.07 12.39 5.71 13 6.5 13C7.33 13 8 12.33 8 11.5S7.33 10 6.5 10C5.82 10 5.25 10.46 5.07 11.08C5.47 8 7.91 5.5 11 5.07V6.5C11 7.33 11.67 8 12.5 8H13V8.5C13 9.33 13.67 10 14.5 10H16V10.5C16 11.33 16.67 12 17.5 12H19C19 16.08 15.5 19.36 11.32 18.96M9.5 9C8.67 9 8 8.33 8 7.5S8.67 6 9.5 6 11 6.67 11 7.5 10.33 9 9.5 9M13 12.5C13 13.33 12.33 14 11.5 14S10 13.33 10 12.5 10.67 11 11.5 11 13 11.67 13 12.5M18 14.5C18 15.33 17.33 16 16.5 16S15 15.33 15 14.5 15.67 13 16.5 13 18 13.67 18 14.5Z"
-                        />
-                    </svg>
+<a
+    class="fi-dropdown-list-item fi-ac-grouped-action js-lcc-settings-toggle"
+    href="#"
+    @click="$dispatch('open-modal', { id: '{{ \Statikbe\CookieConsent\CookieConsentServiceProvider::COOKIE_CONSENT_SETTINGS_MODAL_ID }}' })"
+>
+    <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="fi-icon fi-size-lg fi-sidebar-item-icon"
+        fill="currentColor"
+        data-slot="icon"
+        viewBox="0 0 24 24"
+    >
+        <path
+            d="M20.87 10.5C20.6 10 20 10 20 10H18V9C18 8 17 8 17 8H15V7C15 6 14 6 14 6H13V4C13 3 12 3 12 3C7.03 3 3 7.03 3 12C3 16.97 7.03 21 12 21C16.97 21 21 16.97 21 12C21 11.5 20.96 11 20.87 10.5M11.32 18.96C12 18.82 12.5 18.22 12.5 17.5C12.5 16.67 11.83 16 11 16S9.5 16.67 9.5 17.5C9.5 18 9.76 18.47 10.16 18.74C7.54 18.04 5.5 15.81 5.09 13.12C5 12.61 5 12.11 5 11.62C5.07 12.39 5.71 13 6.5 13C7.33 13 8 12.33 8 11.5S7.33 10 6.5 10C5.82 10 5.25 10.46 5.07 11.08C5.47 8 7.91 5.5 11 5.07V6.5C11 7.33 11.67 8 12.5 8H13V8.5C13 9.33 13.67 10 14.5 10H16V10.5C16 11.33 16.67 12 17.5 12H19C19 16.08 15.5 19.36 11.32 18.96M9.5 9C8.67 9 8 8.33 8 7.5S8.67 6 9.5 6 11 6.67 11 7.5 10.33 9 9.5 9M13 12.5C13 13.33 12.33 14 11.5 14S10 13.33 10 12.5 10.67 11 11.5 11 13 11.67 13 12.5M18 14.5C18 15.33 17.33 16 16.5 16S15 15.33 15 14.5 15.67 13 16.5 13 18 13.67 18 14.5Z"
+        />
+    </svg>
 
-                    <span
-                        class="fi-sidebar-item-label flex-1 truncate text-sm font-medium text-gray-700 dark:text-gray-200"
-                    >
-                        @lang('cookie-consent::texts.alert_settings')
-                    </span>
-                </a>
-            </li>
-        </ul>
-    </li>
-</ul>
+    <span class="fi-dropdown-list-item-label">@lang('cookie-consent::texts.alert_settings')</span>
+</a>

--- a/resources/views/index-filament.blade.php
+++ b/resources/views/index-filament.blade.php
@@ -29,6 +29,10 @@
                     '{{ json_encode(config('cookie-consent.ignored_paths', [])) }}',
                 SESSION_DOMAIN: '{{ config('session.domain') }}',
                 COOKIE_SECURE: '{{ config('cookie-consent.cookie_secure', false) }}',
+                COOKIE_CONSENT_MODAL_ID:
+                    '{{ \Statikbe\CookieConsent\CookieConsentServiceProvider::COOKIE_CONSENT_MODAL_ID }}',
+                COOKIE_CONSENT_SETTINGS_MODAL_ID:
+                    '{{ \Statikbe\CookieConsent\CookieConsentServiceProvider::COOKIE_CONSENT_SETTINGS_MODAL_ID }}',
             })"
 >
     {{-- COOKIE CONSENT MODAL --}}
@@ -36,7 +40,7 @@
         :close-button="false"
         :close-by-escaping="false"
         :close-by-clicking-away="false"
-        id="cookie-consent-modal"
+        id="{{ \Statikbe\CookieConsent\CookieConsentServiceProvider::COOKIE_CONSENT_MODAL_ID }}"
         width="lg"
         heading="{{ $cookieModalHeading }}"
         description="{!! $cookieModalDescription !!}"
@@ -57,7 +61,11 @@
     </x-filament::modal>
 
     {{-- COOKIE SETTINGS MODAL --}}
-    <x-filament::modal id="cookie-consent-settings-modal" width="lg" heading="{{ $settingsModalHeading }}">
+    <x-filament::modal
+        id="{{ \Statikbe\CookieConsent\CookieConsentServiceProvider::COOKIE_CONSENT_SETTINGS_MODAL_ID }}"
+        width="lg"
+        heading="{{ $settingsModalHeading }}"
+    >
         <x-filament::modal.description class="-mt-4">
             {!! $settingsModalDescription !!}
         </x-filament::modal.description>

--- a/src/CookieConsentServiceProvider.php
+++ b/src/CookieConsentServiceProvider.php
@@ -2,11 +2,16 @@
 
 namespace Statikbe\CookieConsent;
 
+use Filament\Support\Facades\FilamentView;
+use Filament\View\PanelsRenderHook;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\ServiceProvider;
 
 class CookieConsentServiceProvider extends ServiceProvider
 {
+    public const string COOKIE_CONSENT_MODAL_ID = 'cookie-consent-modal';
+    public const string COOKIE_CONSENT_SETTINGS_MODAL_ID = 'cookie-consent-settings-modal';
+
     public function boot(): void
     {
         $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'cookie-consent');
@@ -18,6 +23,18 @@ class CookieConsentServiceProvider extends ServiceProvider
         // Publishing is only necessary when using the CLI.
         if ($this->app->runningInConsole()) {
             $this->bootForConsole();
+        }
+        
+        if (
+            config('cookie-consent.theme') === 'filament'
+            && ! config('cookie-consent.disable_filament_nav_hook', false)
+            && class_exists(FilamentView::class)
+            && class_exists(PanelsRenderHook::class)
+        ) {
+            FilamentView::registerRenderHook(
+                PanelsRenderHook::SIDEBAR_NAV_END,
+                fn () => view('cookie-consent::filament-nav-item'),
+            );
         }
     }
 

--- a/src/CookieConsentServiceProvider.php
+++ b/src/CookieConsentServiceProvider.php
@@ -28,12 +28,12 @@ class CookieConsentServiceProvider extends ServiceProvider
 
         if (
             config('cookie-consent.theme') === 'filament'
-            && ! config('cookie-consent.disable_filament_nav_hook', false)
+            && config('cookie-consent.filament-nav-item-render-hook') !== null
             && class_exists(FilamentView::class)
             && class_exists(PanelsRenderHook::class)
         ) {
             FilamentView::registerRenderHook(
-                PanelsRenderHook::SIDEBAR_NAV_END,
+                config('cookie-consent.filament-nav-item-render-hook'),
                 fn () => view('cookie-consent::filament-nav-item'),
             );
         }

--- a/src/CookieConsentServiceProvider.php
+++ b/src/CookieConsentServiceProvider.php
@@ -19,9 +19,9 @@ class CookieConsentServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'cookie-consent');
 
-        $this->publishes([
-            __DIR__.'/../resources/views/filament-nav-item.blade.php' => resource_path('views/vendor/cookie-consent/filament-nav-item.blade.php'),
-        ], 'cookie-consent-filament-nav-item');
+        // $this->publishes([
+        //     __DIR__.'/../resources/views/filament-nav-item.blade.php' => resource_path('views/vendor/cookie-consent/filament-nav-item.blade.php'),
+        // ], 'cookie-consent-filament-nav-item');
 
         $this->app['view']->composer('cookie-consent::index', function (View $view) {});
 

--- a/src/CookieConsentServiceProvider.php
+++ b/src/CookieConsentServiceProvider.php
@@ -19,10 +19,6 @@ class CookieConsentServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'cookie-consent');
 
-        // $this->publishes([
-        //     __DIR__.'/../resources/views/filament-nav-item.blade.php' => resource_path('views/vendor/cookie-consent/filament-nav-item.blade.php'),
-        // ], 'cookie-consent-filament-nav-item');
-
         $this->app['view']->composer('cookie-consent::index', function (View $view) {});
 
         // Publishing is only necessary when using the CLI.

--- a/src/CookieConsentServiceProvider.php
+++ b/src/CookieConsentServiceProvider.php
@@ -10,6 +10,7 @@ use Illuminate\Support\ServiceProvider;
 class CookieConsentServiceProvider extends ServiceProvider
 {
     public const string COOKIE_CONSENT_MODAL_ID = 'cookie-consent-modal';
+
     public const string COOKIE_CONSENT_SETTINGS_MODAL_ID = 'cookie-consent-settings-modal';
 
     public function boot(): void
@@ -18,13 +19,17 @@ class CookieConsentServiceProvider extends ServiceProvider
 
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'cookie-consent');
 
+        $this->publishes([
+            __DIR__.'/../resources/views/filament-nav-item.blade.php' => resource_path('views/vendor/cookie-consent/filament-nav-item.blade.php'),
+        ], 'cookie-consent-filament-nav-item');
+
         $this->app['view']->composer('cookie-consent::index', function (View $view) {});
 
         // Publishing is only necessary when using the CLI.
         if ($this->app->runningInConsole()) {
             $this->bootForConsole();
         }
-        
+
         if (
             config('cookie-consent.theme') === 'filament'
             && ! config('cookie-consent.disable_filament_nav_hook', false)


### PR DESCRIPTION
### Description

Added a self-registering navigation item for filament apps so users can edit their cookie settings when they are logged in to filament.
Added a config option to disable this behaviour if users prefer to publish this view and register the nav item themselves.

Also improved the way we open the modals -> put the id's into a constant.

### Reason for this change

We have this navigation item for youcrn and ovbtel, now all filament projects have access to this feature!

<img width="291" height="228" alt="image" src="https://github.com/user-attachments/assets/25310029-349d-4ccd-b2e1-0d0659a5f6cb" />
