### PR TITLE
Add missing Filament translations for all languages

### DIFF
--- a/resources/lang/en/texts.php
+++ b/resources/lang/en/texts.php
@@ -21,4 +21,7 @@ return [
     'settings_save' => 'Save my selection',
     'settings_title' => 'Cookie settings',
     'settings_text' => 'Our website stores four types of cookies. At any time you can choose which cookies you accept and which you refuse. You can read more about what cookies are and what types of cookies we store in our  <a href=":policyUrl" target="_blank" class="underline hover:no-underline">Cookie Policy</a>.',
+    'filament' => [
+        'settings_text' => 'Our website stores four types of cookies. At any time you can choose which cookies you accept and which you refuse. You can read more about what cookies are and what types of cookies we store in our <x-filament::link href=":policyUrl" target="_blank">cookie policy</x-filament::link>.',
+    ],
 ];

--- a/resources/lang/es/texts.php
+++ b/resources/lang/es/texts.php
@@ -21,4 +21,7 @@ return [
     'settings_save' => 'Guardar mi selección',
     'settings_title' => 'Configuración de cookies',
     'settings_text' => 'Nuestro sitio web almacena cuatro tipos de cookies. En cualquier momento puede elegir qué cookies acepta y cuáles rechaza. Puede obtener más información sobre qué son las cookies y qué tipos de cookies almacenamos en nuestra <a href=":policyUrl" target="_blank" class="underline hover:no-underline">Política de cookies</a>.',
+    'filament' => [
+        'settings_text' => 'Nuestro sitio web almacena cuatro tipos de cookies. En cualquier momento puede elegir qué cookies acepta y cuáles rechaza. Puede obtener más información sobre qué son las cookies y qué tipos de cookies almacenamos en nuestra <x-filament::link href=":policyUrl" target="_blank">política de cookies</x-filament::link>.',
+    ],
 ];

--- a/resources/lang/fr/texts.php
+++ b/resources/lang/fr/texts.php
@@ -21,4 +21,7 @@ return [
     'settings_save' => 'Sauvegarder mon choix',
     'settings_title' => 'Cookie settings',
     'settings_text' => 'Notre site web stocke quatre types de cookies. À tout moment, vous pouvez choisir celles que vous acceptez et celles que vous refusez. Vous pouvez en savoir plus sur ce que sont les cookies et sur les types de cookies que nous stockons dans notre <a href=":policyUrl" target="_blank">politique en matière de cookies</a>.',
+    'filament' => [
+        'settings_text' => 'Notre site web stocke quatre types de cookies. À tout moment, vous pouvez choisir celles que vous acceptez et celles que vous refusez. Vous pouvez en savoir plus sur ce que sont les cookies et sur les types de cookies que nous stockons dans notre <x-filament::link href=":policyUrl" target="_blank">politique en matière de cookies</x-filament::link>.',
+    ],
 ];

--- a/resources/lang/oc/texts.php
+++ b/resources/lang/oc/texts.php
@@ -21,4 +21,7 @@ return [
     'settings_save' => 'Enregistrar ma seleccion',
     'settings_title' => 'Paramètres de cookie',
     'settings_text' => 'Nòstre site web salva quatre tipes de cookies. Quand volètz podètz causir quines cookies autorizatz e los refusatz. Podètz ne legir mai a prepaus dels cookies e de çò que enregistram dins nòstra <a href=":policyUrl" target="_blank" class="underline hover:no-underline">Politica de confidencialitat</a>.',
+    'filament' => [
+        'settings_text' => 'Nòstre site web salva quatre tipes de cookies. Quand volètz podètz causir quines cookies autorizatz e los refusatz. Podètz ne legir mai a prepaus dels cookies e de çò que enregistram dins nòstra <x-filament::link href=":policyUrl" target="_blank">politica de cookies</x-filament::link>.',
+    ],
 ];


### PR DESCRIPTION
This PR adds the missing \`filament.settings_text\` translation key to all language files:

- **en** (English)
- **es** (Spanish)
- **fr** (French)
- **oc** (Occitan)

Each translation uses the Filament \`<x-filament::link>\` component, matching the existing Dutch translation structure.