### PR TITLE
Remove banner script injection from error pages

### DIFF
--- a/config/cookie-consent.php
+++ b/config/cookie-consent.php
@@ -17,6 +17,11 @@ return [
     'cookie_expiration_days' => '365',
     'gtm_event' => 'cookie_refresh',
     'ignored_paths' => [],
+    /**
+     * Skip cookie consent on error responses (4xx and 5xx status codes).
+     * Set to true if you want to disable cookie banner on error pages.
+     */
+    'skip_on_error_responses' => false,
     'cookie_secure' => env('COOKIE_CONSENT_SECURE', false),
     'policy_url_en' => env('COOKIE_POLICY_URL_EN', null),
     'policy_url_fr' => env('COOKIE_POLICY_URL_FR', null),

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,7 @@ This only works when Google Tag Manager is correctly configured (some regex conf
     - [Customising the dialog contents](#customising-the-dialog-contents)
     - [Publishing](#publishing)
         - [Config](#config)
+        - [Skip cookie consent on error pages](#skip-cookie-consent-on-error-pages)
         - [Translations](#translations)
         - [Views](#views)
 - [Configure Google Tag Manager](#configure-google-tag-manager)
@@ -218,6 +219,11 @@ return [
     'cookie_expiration_days' => '365',
     'gtm_event' => 'pageview',
     'ignored_paths' => [],
+    /**
+     * Skip cookie consent on error responses (4xx and 5xx status codes).
+     * Set to true if you want to disable cookie banner on error pages.
+     */
+    'skip_on_error_responses' => false,
     'cookie_secure' => env('COOKIE_CONSENT_SECURE', false),
     'policy_url_en' => env('COOKIE_POLICY_URL_EN', null),
     'policy_url_fr' => env('COOKIE_POLICY_URL_FR', null),
@@ -233,6 +239,14 @@ If you don't want the modal to be shown on certain pages you can add the relativ
 
 ```
 'ignored_paths => ['/en/cookie-policy', '/api/documentation*'];
+```
+
+#### Skip cookie consent on error pages
+
+By default, the cookie consent banner is shown on error pages (404, 500, etc.). If you want to disable the banner on error responses, you can set this option to `true`:
+
+```
+'skip_on_error_responses' => true,
 ```
 
 #### Translations

--- a/src/CookieConsentMiddleware.php
+++ b/src/CookieConsentMiddleware.php
@@ -16,8 +16,10 @@ class CookieConsentMiddleware
             return $response;
         }
 
-        if ($response->isClientError() || $response->isServerError()) {
-            return $response;
+        if (config('cookie-consent.skip_on_error_responses', false)) {
+            if ($response->isClientError() || $response->isServerError()) {
+                return $response;
+            }
         }
 
         if (! $this->containsBodyTag($response)) {

--- a/src/CookieConsentMiddleware.php
+++ b/src/CookieConsentMiddleware.php
@@ -16,6 +16,10 @@ class CookieConsentMiddleware
             return $response;
         }
 
+        if ($response->isClientError() || $response->isServerError()) {
+            return $response;
+        }
+
         if (! $this->containsBodyTag($response)) {
             return $response;
         }


### PR DESCRIPTION
Hello,
_It's my first PR to this repo, and one of a few I made to Open Source, so please don't beat me if I did something wrong. I just tried to fix a problem that occured on my projects. Hopefully helpful to everyone else. I tried the cleanest approach I could imagine._

### Description
Problem:
The cookie banner script is injected into 404, 500 and other error message Laravel subpages.
Fix:
  - Update CookieConsentMiddleware.php: Added a check before content injection that skips cookie consent for any error responses
  - This means 404, 500, and all other error pages will no longer display the cookie consent banner

### Reason for this change
The cookie banner script is injected into 404, 500 and other error message Laravel subpages, which is not the expected behavior IMO.