### PR TITLE
INTLAR-226 README and GTM docs rewrite and dependabot merge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,3 @@ composer.lock
 !.yarn/sdks
 !.yarn/versions
 .pnp.*
-.yarnrc.yml

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,8 @@
+nodeLinker: node-modules
+
+approvedGitRepositories:
+  - "**"
+
+enableScripts: true
+
+npmMinimalAgeGate: 0

--- a/docs/google-tag-manager.md
+++ b/docs/google-tag-manager.md
@@ -1,5 +1,11 @@
 # How to configure Google Tag Manager
 
+> **Note:** Google Universal Analytics (UA) was sunset in July 2024.
+> These steps apply to GA4 (Google Analytics 4) containers.
+> The consent trigger and variable configuration is identical — only the tag type differs.
+> Where these instructions reference a "Google Analytics: Universal Analytics" tag,
+> use "Google Analytics: GA4 Configuration" or "Google Analytics: GA4 Event" instead.
+
 ## Step 1: Create new variable
 - Name: `GDPR Consent level` 
 - Variable type: 1st Party Cookie
@@ -30,7 +36,8 @@ _Exceptions on a trigger_
 It's possible that there are no tags created yet. If that's the case, create a new one (click right top 'new')
 Give it the name `Google Analytics` (Or you can give this another name, but keep that in mind when you follow the next steps).
  
- For Tag Type you choose `Google Analytics: Universal Analytics`.
+ For Tag Type choose `Google Analytics: GA4 Configuration` (or `GA4 Event` for event tags).
+The existing screenshot shows the old Universal Analytics interface — the principle is the same for GA4.
 ![Create tag](img/step3.png?raw=true "Create tag")
 _Tag with some settings already set after config_
 

--- a/package.json
+++ b/package.json
@@ -19,5 +19,6 @@
     },
     "dependencies": {
         "wicg-inert": "^3.0.3"
-    }
+    },
+    "packageManager": "yarn@4.17.0+sha512.c2957de2f9025ab14d63b24d0d8be1f1655810e22c341042c27f7ecd017b180ec12db73d69ac366d71b304ef9f069349ce462de96f04f8f1da317f4f762c95ae"
 }

--- a/readme.md
+++ b/readme.md
@@ -2,275 +2,298 @@
 
 # Laravel cookie consent modal
 
-[![Latest Version on Packagist](https://img.shields.io/packagist/v/statikbe/laravel-cookie-consent.svg?style=flat-square)](https://packagist.org/packages/statikbe/llaravel-cookie-consent)
+[![Latest Version on Packagist](https://img.shields.io/packagist/v/statikbe/laravel-cookie-consent.svg?style=flat-square)](https://packagist.org/packages/statikbe/laravel-cookie-consent)
 [![Total Downloads](https://img.shields.io/packagist/dt/statikbe/laravel-cookie-consent.svg?style=flat-square)](https://packagist.org/packages/statikbe/laravel-cookie-consent)
 
 ![Modal cookie consent](docs/img/modal.png?raw=true 'Modal for Cookie consent')
 
 ![Preferences Modal](docs/img/preferences.png?raw=true 'Preferences for cookies')
 
-The package includes a script & styling for a cookie banner and a modal where the visitor can select his/her cookie preferences.
+Cookie banner and preferences modal for Laravel. Visitors choose which cookie categories they accept; Google Tag Manager reads the resulting cookie to decide which tags fire. Based on [spatie/laravel-cookie-consent](https://github.com/spatie/laravel-cookie-consent) with added per-category consent.
 
-This package is mainly based on the one from spatie: https://github.com/spatie/laravel-cookie-consent
+## Requirements
 
-With the only exception that you can choose which cookies you enable.
-This only works when Google Tag Manager is correctly configured (some regex config based on the value set in the cookie).
-
-- [Upgrading](upgrading.md)
-- [Installation](#installation)
-- [Usage](#usage)
-- [Customising the dialog texts](#customising-the-dialog-texts)
-    - [Customising the dialog contents](#customising-the-dialog-contents)
-    - [Publishing](#publishing)
-        - [Config](#config)
-        - [Skip cookie consent on error pages](#skip-cookie-consent-on-error-pages)
-        - [Translations](#translations)
-        - [Views](#views)
-- [Configure Google Tag Manager](#configure-google-tag-manager)
-- [Security](#security)
-- [License](#license)
+| Laravel | PHP  |
+|---------|------|
+| 10–13   | 8.0+ |
 
 ## Upgrading
 
-You can find our upgrading guides [here](upgrading.md).
+See [upgrading.md](upgrading.md).
+
+## Table of contents
+
+- [Installation](#installation)
+- [Configuration](#configuration)
+- [Filament Integration](#filament-integration)
+- [Customisation](#customisation)
+- [Google Tag Manager](#google-tag-manager)
+- [Security](#security)
+- [License](#license)
 
 ## Installation
 
-You can install the package via composer:
+### 1. Install via Composer
 
 ```bash
 composer require statikbe/laravel-cookie-consent
 ```
 
-The package will automatically register itself.
+The package registers itself automatically.
 
-First of all **you need to** publish the javascript and css files:
+### 2. Register the middleware
+
+**Laravel 11 and later** — in `bootstrap/app.php`:
+
+```php
+->withMiddleware(function (Middleware $middleware) {
+    $middleware->web(append: [
+        \Statikbe\CookieConsent\CookieConsentMiddleware::class,
+    ]);
+})
+```
+
+Or as a named alias:
+
+```php
+->withMiddleware(function (Middleware $middleware) {
+    $middleware->alias([
+        'cookie-consent' => \Statikbe\CookieConsent\CookieConsentMiddleware::class,
+    ]);
+})
+```
+
+**Laravel 10 and earlier** — in `app/Http/Kernel.php`:
+
+```php
+protected $middlewareGroups = [
+    'web' => [
+        // ...
+        \Statikbe\CookieConsent\CookieConsentMiddleware::class,
+    ],
+];
+```
+
+Or as a named middleware applied to specific routes:
+
+```php
+// app/Http/Kernel.php
+protected $routeMiddleware = [
+    'cookie-consent' => \Statikbe\CookieConsent\CookieConsentMiddleware::class,
+];
+
+// routes/web.php
+Route::middleware('cookie-consent')->group(function () {
+    // ...
+});
+```
+
+The middleware injects the cookie consent snippet into every HTML response before the closing `</body>` tag.
+
+### 3. Publish the assets
 
 ```bash
 php artisan vendor:publish --provider="Statikbe\CookieConsent\CookieConsentServiceProvider" --tag="cookie-public"
 ```
 
-When using the default theme, make sure to include the css/cookie-consent.css into your base.blade.php or any other base template you use.
+### 4. Include the stylesheet (default theme only)
 
-```
-<link rel="stylesheet" type="text/css" href="{{asset("vendor/cookie-consent/css/cookie-consent.css")}}">
-```
-
-If you want to use the filament theme, make sure to source the blade files in your tailwind config
-
-tailwind v4:
-```css
-/* point to the actual vendor location */
-@source 'vendor/statikbe/laravel-cookie-consent/resources/**/*.blade.php';
-```
-tailwind v3 and below:
-```js
-export default {
-    content: [
-        'vendor/statikbe/laravel-cookie-consent/resources/**/*.blade.php';
-    ]
-}
-```
-
-The javascript file is included in the cookie snippet and will be added at the end of your body.
-
-If you want to show the filament themed cookie banner outside of your filament panel, also make sure that you include the filament styles and scripts in your templates.
-
-## Usage
-
-Instead of including a snippet in your view, we will automatically add it. This is done using middleware using two methods:
-
-**For Laravel 11.x and newer**
-
-```php
-// bootstrap/app.php
-
-->withMiddleware(function (Middleware $middleware) {
-    ...
-    $middleware->web(append: [
-        ...
-        \Statikbe\CookieConsent\CookieConsentMiddleware::class,
-    ]);
-
-// OR AS AN ALIAS
-
-    $middleware->alias([
-        ...
-        'cookie-consent' => \Statikbe\CookieConsent\CookieConsentMiddleware::class,
-    ]);
-})
-
-```
-
-**For Laravel 10.x and earlier**
-
-```php
-// app/Http/Kernel.php
-
-class Kernel extends HttpKernel
-{
-    protected $middleware = [
-        // ...
-        \Statikbe\CookieConsent\CookieConsentMiddleware::class,
-    ];
-
-     protected $routeMiddleware = [
-        // ...
-        'cookie-consent' => \Statikbe\CookieConsent\CookieConsentMiddleware::class,
-    ];
-
-
-// routes/web.php
-Route::group([
-    'middleware' => ['cookie-consent']
-], function(){
-    // ...
-});
-}
-```
-
-This will add `cookieConsent::index` to the content of your response right before the closing body tag.
-
-## Customising the dialog texts
-
-If you want to modify the text shown in the dialog you can publish the lang-files with this command:
-
-```bash
-php artisan vendor:publish --provider="Statikbe\CookieConsent\CookieConsentServiceProvider" --tag="cookie-lang"
-```
-
-This will publish this file to `resources/lang/vendor/cookieConsent/en/texts.php`.
-
-```php
-
-return [
-    'alert_title' => 'Deze website gebruikt cookies',
-    'setting_analytics' => 'Analytische cookies',
-];
-```
-
-If you want to translate the values to, for example, English, just copy that file over to `resources/lang/vendor/cookieConsent/fr/texts.php` and fill in the English translations.
-
-### Customising the dialog contents
-
-If you need full control over the contents of the dialog. You can publish the views of the package:
-
-```bash
-php artisan vendor:publish --provider="Statikbe\CookieConsent\CookieConsentServiceProvider" --tag="cookie-views"
-```
-
-This will copy the `index` view file over to `resources/views/vendor/cookieConsent`.
-
-The `cookie-settings` view file is just a snippet you need to place somewhere onto your page. Most preferably in the footer next to the url of your cookie policy.
+Add this to your base template. Skip this step if you are using the Filament theme — see [Filament Integration](#filament-integration).
 
 ```html
-<a href="javascript:void(0)" class="js-lcc-settings-toggle">@lang('cookie-consent::texts.alert_settings')</a>
+<link rel="stylesheet" type="text/css" href="{{ asset('vendor/cookie-consent/css/cookie-consent.css') }}">
 ```
 
-This gives your visitor the opportunity to change the settings again.
+## Configuration
 
-### Customising the theme
-
-By default, the cookie popup will look like this:
-
-![screenshot of default theme](./assets/screenshot-default.png)
-
-If you are however working on a project that is using filament, you can opt to use filament componets to render your cookie popup.
-
-To do this, configure the theme to `filament`
-
-```
-'theme' => 'filament'
-```
-
-This will render the cookie popup like so:
-
-![screenshot of filament theme](./assets/screenshot-filament.png)
-
-### Publishing
-
-#### Config
+Publish the config file:
 
 ```bash
 php artisan vendor:publish --provider="Statikbe\CookieConsent\CookieConsentServiceProvider" --tag="cookie-config"
 ```
 
-This is the contents of the published config-file:
-This will read the policy urls from your env.
+`config/cookie-consent.php`:
 
 ```php
 return [
-    /**
-     * Theme to use for the cookie consent popup.
-     * Available options: 'default', 'filament'.
+    /*
+     * Theme for the cookie consent popup.
+     * Options: 'default', 'filament'
      */
     'theme' => 'default',
-    /**
-     * Filament render hook where the package will
-     * register a navigation item to show the cookie
-     * settings modal. 
-     * Set to null to disable this.
+
+    /*
+     * Filament render hook used to register the cookie settings nav item.
+     * Set to null to disable the nav item entirely.
+     * See: Filament Integration > Nav item
      */
-    'filament-nav-item-render-hook' => PanelsRenderHook::USER_MENU_PROFILE_AFTER,
-    'disable_filament_nav_hook' => false,
+    'filament-nav-item-render-hook' => \Filament\View\PanelsRenderHook::USER_MENU_PROFILE_AFTER,
+
+    /*
+     * Name of the cookie written to the browser.
+     * If you change this, update the GTM variable name to match.
+     */
     'cookie_key' => '__cookie_consent',
+
+    /*
+     * Values written to the cookie for each consent choice.
+     *
+     *   analytics only  => '2'
+     *   marketing only  => '3'
+     *   both accepted   => 'true'
+     *   none accepted   => 'false'
+     *
+     * GTM reads this value with regex triggers to decide which tags fire.
+     * If you change these values, update your GTM triggers to match.
+     */
     'cookie_value_analytics' => '2',
     'cookie_value_marketing' => '3',
     'cookie_value_both' => 'true',
     'cookie_value_none' => 'false',
+
     'cookie_expiration_days' => '365',
-    'gtm_event' => 'pageview',
+
+    /*
+     * GTM custom event fired after the visitor saves their preferences.
+     */
+    'gtm_event' => 'cookie_refresh',
+
+    /*
+     * Relative paths where the cookie banner is suppressed.
+     * Accepts wildcards via Str::is() — e.g. '/api/*', '/en/cookie-policy'.
+     */
     'ignored_paths' => [],
-    /**
-     * Skip cookie consent on error responses (4xx and 5xx status codes).
-     * Set to true if you want to disable cookie banner on error pages.
+
+    /*
+     * Set to true to suppress the banner on 4xx/5xx error pages.
      */
     'skip_on_error_responses' => false,
+
+    /*
+     * Mark the consent cookie as Secure (HTTPS only).
+     * Reads from the COOKIE_CONSENT_SECURE env variable.
+     */
     'cookie_secure' => env('COOKIE_CONSENT_SECURE', false),
+
+    /*
+     * Cookie policy page URLs shown in the banner.
+     * Read from env — add only the locales your site supports.
+     */
     'policy_url_en' => env('COOKIE_POLICY_URL_EN', null),
     'policy_url_fr' => env('COOKIE_POLICY_URL_FR', null),
     'policy_url_nl' => env('COOKIE_POLICY_URL_NL', null),
 ];
 ```
 
-You can customize some settings that work with your GTM.
+### Hiding the banner on specific pages
 
-#### Don't show modal on cookie policy page or other pages
-
-If you don't want the modal to be shown on certain pages you can add the relative url to the ignored paths setting. This also accepts wildcards (see the Laravel `Str::is()` [helper](https://laravel.com/docs/9.x/helpers#method-str-is)).
-
-```
-'ignored_paths => ['/en/cookie-policy', '/api/documentation*'];
+```php
+'ignored_paths' => ['/en/cookie-policy', '/api/documentation*'],
 ```
 
-#### Skip cookie consent on error pages
+Wildcards use Laravel's [`Str::is()`](https://laravel.com/docs/helpers#method-str-is) matching.
 
-By default, the cookie consent banner is shown on error pages (404, 500, etc.). If you want to disable the banner on error responses, you can set this option to `true`:
+### Hiding the banner on error pages
 
-```
+```php
 'skip_on_error_responses' => true,
 ```
 
-#### Translations
+## Filament Integration
+
+If your project uses [Filament](https://filamentphp.com), you can render the cookie banner using Filament components instead of the default styled theme.
+
+### 1. Enable the Filament theme
+
+```php
+// config/cookie-consent.php
+'theme' => 'filament',
+```
+
+This will render the cookie popup using Filament components:
+
+![screenshot of filament theme](./assets/screenshot-filament.png)
+
+The default theme looks like this for comparison:
+
+![screenshot of default theme](./assets/screenshot-default.png)
+
+### 2. Configure Tailwind to scan the package views
+
+**Tailwind v4** — in your main CSS file:
+
+```css
+@source 'vendor/statikbe/laravel-cookie-consent/resources/**/*.blade.php';
+```
+
+**Tailwind v3** — in `tailwind.config.js`:
+
+```js
+export default {
+    content: [
+        'vendor/statikbe/laravel-cookie-consent/resources/**/*.blade.php',
+    ]
+}
+```
+
+### 3. Filament styles outside the panel
+
+If you display the cookie banner on pages that are not inside a Filament panel, include Filament's CSS and JS in those page templates.
+
+### 4. Cookie settings nav item
+
+When the Filament theme is active, the package registers a "Cookie settings" link in the Filament user menu. The position is controlled by `filament-nav-item-render-hook`, which defaults to after the profile menu item.
+
+To change the position, set a different render hook value:
+
+```php
+'filament-nav-item-render-hook' => \Filament\View\PanelsRenderHook::SIDEBAR_NAV_END,
+```
+
+To remove the nav item entirely:
+
+```php
+'filament-nav-item-render-hook' => null,
+```
+
+## Customisation
+
+### Translations
+
+Publish the language files:
 
 ```bash
 php artisan vendor:publish --provider="Statikbe\CookieConsent\CookieConsentServiceProvider" --tag="cookie-lang"
 ```
 
-#### Views
+Files land in `lang/vendor/cookie-consent/{locale}/texts.php`. To add a new locale, copy the `en` directory to the target locale and translate the strings.
+
+### Views
+
+Publish the view files:
 
 ```bash
 php artisan vendor:publish --provider="Statikbe\CookieConsent\CookieConsentServiceProvider" --tag="cookie-views"
 ```
 
-## Configure Google Tag Manager
+Files land in `resources/views/vendor/cookie-consent`.
 
-All the steps to configure your Google Tag Manager can be found [here](docs/google-tag-manager.md).
+To let visitors re-open the preferences modal (e.g. from your footer next to the cookie policy link):
+
+```html
+<a href="javascript:void(0)" class="js-lcc-settings-toggle">
+    @lang('cookie-consent::texts.alert_settings')
+</a>
+```
+
+## Google Tag Manager
+
+Set up GTM to read the consent cookie and control which tags fire. Full setup instructions: [docs/google-tag-manager.md](docs/google-tag-manager.md).
 
 ## Security
 
-If you discover any security related issues, please email [info@statik.be](mailto:info@statik.be) instead of using the issue tracker.
+If you discover a security issue, please email [info@statik.be](mailto:info@statik.be) instead of using the issue tracker.
 
 ## License
 
-The MIT License (MIT). Please see [License File](LICENSE.md) for more information.
+The MIT License (MIT). Please see [License File](license.md) for more information.

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.27.1":

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,26 +34,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/compat-data@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/compat-data@npm:7.29.7"
+  checksum: 8/4424f8fb72f61657c8e811bdf7e5c69af212a15fe362711162b2e00b82f0e0588fb8259ecd9a70c5490562bf51d408b0cb92f277ead71a2390ddddfe7283b35d
+  languageName: node
+  linkType: hard
+
 "@babel/core@npm:^7.15.8":
-  version: 7.28.5
-  resolution: "@babel/core@npm:7.28.5"
+  version: 7.29.7
+  resolution: "@babel/core@npm:7.29.7"
   dependencies:
-    "@babel/code-frame": "npm:^7.27.1"
-    "@babel/generator": "npm:^7.28.5"
-    "@babel/helper-compilation-targets": "npm:^7.27.2"
-    "@babel/helper-module-transforms": "npm:^7.28.3"
-    "@babel/helpers": "npm:^7.28.4"
-    "@babel/parser": "npm:^7.28.5"
-    "@babel/template": "npm:^7.27.2"
-    "@babel/traverse": "npm:^7.28.5"
-    "@babel/types": "npm:^7.28.5"
-    "@jridgewell/remapping": "npm:^2.3.5"
-    convert-source-map: "npm:^2.0.0"
-    debug: "npm:^4.1.0"
-    gensync: "npm:^1.0.0-beta.2"
-    json5: "npm:^2.2.3"
-    semver: "npm:^6.3.1"
-  checksum: 535f82238027621da6bdffbdbe896ebad3558b311d6f8abc680637a9859b96edbf929ab010757055381570b29cf66c4a295b5618318d27a4273c0e2033925e72
+    "@babel/code-frame": ^7.29.7
+    "@babel/generator": ^7.29.7
+    "@babel/helper-compilation-targets": ^7.29.7
+    "@babel/helper-module-transforms": ^7.29.7
+    "@babel/helpers": ^7.29.7
+    "@babel/parser": ^7.29.7
+    "@babel/template": ^7.29.7
+    "@babel/traverse": ^7.29.7
+    "@babel/types": ^7.29.7
+    "@jridgewell/remapping": ^2.3.5
+    convert-source-map: ^2.0.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.2
+    json5: ^2.2.3
+    semver: ^6.3.1
+  checksum: 8/95149e98ffde5b9d903459c284fbcf1f9ad8b3a833d69fdfe1aa7185821a102af1925324fe2892caf4b643b151c1dc948510d1e25a5e3c6c6c6f17f6712eb38e
   languageName: node
   linkType: hard
 
@@ -102,6 +109,19 @@ __metadata:
     lru-cache: "npm:^5.1.1"
     semver: "npm:^6.3.1"
   checksum: f338fa00dcfea931804a7c55d1a1c81b6f0a09787e528ec580d5c21b3ecb3913f6cb0f361368973ce953b824d910d3ac3e8a8ee15192710d3563826447193ad1
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-compilation-targets@npm:7.29.7"
+  dependencies:
+    "@babel/compat-data": ^7.29.7
+    "@babel/helper-validator-option": ^7.29.7
+    browserslist: ^4.24.0
+    lru-cache: ^5.1.1
+    semver: ^6.3.1
+  checksum: 8/f60a943937f4eba0e671aa28551cb45569fd081c1e30a52ede167860475dc0417f3dbdf2a0fa3f086965595c7070aa76308da60cc0319860de05db4ed2a431f7
   languageName: node
   linkType: hard
 
@@ -194,7 +214,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.27.1, @babel/helper-module-transforms@npm:^7.28.3":
+"@babel/helper-module-transforms@npm:^7.27.1":
   version: 7.28.3
   resolution: "@babel/helper-module-transforms@npm:7.28.3"
   dependencies:
@@ -314,6 +334,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-option@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-option@npm:7.29.7"
+  checksum: 8/aeb6aa966f59300d3cc2fea7c68e1dfd7ad011fc10e535c8e2b2de3094b27c859428dc7220f16420350f8b1cde99da120b673be04bcb0c2f37b56258c96bed58
+  languageName: node
+  linkType: hard
+
 "@babel/helper-wrap-function@npm:^7.27.1":
   version: 7.28.3
   resolution: "@babel/helper-wrap-function@npm:7.28.3"
@@ -325,13 +352,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.28.4":
-  version: 7.28.4
-  resolution: "@babel/helpers@npm:7.28.4"
+"@babel/helpers@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helpers@npm:7.29.7"
   dependencies:
-    "@babel/template": "npm:^7.27.2"
-    "@babel/types": "npm:^7.28.4"
-  checksum: aaa5fb8098926dfed5f223adf2c5e4c7fbba4b911b73dfec2d7d3083f8ba694d201a206db673da2d9b3ae8c01793e795767654558c450c8c14b4c2175b4fcb44
+    "@babel/template": ^7.29.7
+    "@babel/types": ^7.29.7
+  checksum: 8/b5c4ed0ce5983c5599cd01b3948444b77ba2fa47bf6282a82afdcbe45eb8cc5b7986194e3920ef2760f533c6a775504e6b00a66960c0a3bc52909920b8433908
   languageName: node
   linkType: hard
 
@@ -1265,7 +1292,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.4, @babel/types@npm:^7.28.5, @babel/types@npm:^7.4.4":
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.5, @babel/types@npm:^7.4.4":
   version: 7.28.5
   resolution: "@babel/types@npm:7.28.5"
   dependencies:
@@ -7034,7 +7061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:^1.8.3, shell-quote@npm:^1.8.4":
+"shell-quote@npm:^1.8.4":
   version: 1.8.4
   resolution: "shell-quote@npm:1.8.4"
   checksum: 8/082dc836baa8ade01144ee3068af487ea45ba570ea6ab13a5eddc11ab16a976b8857b51ef2caf7dc9a1e173ff0aea685b8f78b4f6f5a0a1ef24c7b17c51350e2

--- a/yarn.lock
+++ b/yarn.lock
@@ -4534,9 +4534,9 @@ __metadata:
   linkType: hard
 
 "ip-address@npm:^10.0.1":
-  version: 10.1.0
-  resolution: "ip-address@npm:10.1.0"
-  checksum: 0103516cfa93f6433b3bd7333fa876eb21263912329bfa47010af5e16934eeeff86f3d2ae700a3744a137839ddfad62b900c7a445607884a49b5d1e32a3d7566
+  version: 10.2.0
+  resolution: "ip-address@npm:10.2.0"
+  checksum: 8/3ffba04dc4cdaf81ed2ed6edc47eee1494bb97550ef73f1918ca28405d175c03efa416b8337e868123b08c2cc677e3a07c5ce03eda3b1aeb2741c149bd37ddf9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4354,20 +4354,20 @@ __metadata:
   linkType: hard
 
 "http-proxy-middleware@npm:^2.0.3":
-  version: 2.0.9
-  resolution: "http-proxy-middleware@npm:2.0.9"
+  version: 2.0.10
+  resolution: "http-proxy-middleware@npm:2.0.10"
   dependencies:
-    "@types/http-proxy": "npm:^1.17.8"
-    http-proxy: "npm:^1.18.1"
-    is-glob: "npm:^4.0.1"
-    is-plain-obj: "npm:^3.0.0"
-    micromatch: "npm:^4.0.2"
+    "@types/http-proxy": ^1.17.8
+    http-proxy: ^1.18.1
+    is-glob: ^4.0.1
+    is-plain-obj: ^3.0.0
+    micromatch: ^4.0.2
   peerDependencies:
     "@types/express": ^4.17.13
   peerDependenciesMeta:
     "@types/express":
       optional: true
-  checksum: 8e9032af625f7c9f2f0d318f6cdb14eb725cc16ffe7b4ccccea25cf591fa819bb7c3bb579e0b543e0ae9c73059b505a6d728290c757bff27bae526a6ed11c05e
+  checksum: 8/94dd3289f888021089ae6beb96c492ecfc0d2ea78fccf97f861ac1772c8ba471cf5f8cb17911d66d6084a9943db4deec841cc0b097b5dec21955e94e7c16dc64
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4964,9 +4964,9 @@ __metadata:
   linkType: hard
 
 "lodash@npm:^4.17.21":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+  version: 4.18.1
+  resolution: "lodash@npm:4.18.1"
+  checksum: 8/bb5f5b49aad29614e709af02b64c56b0f8b78c6a81434a3c1ae527d2f0f78ca08f9d9fb22aa825a053876c9d2166e9c01f31c356014b5e2bdc0556c057433102
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3785,9 +3785,9 @@ __metadata:
   linkType: hard
 
 "fast-uri@npm:^3.0.1":
-  version: 3.1.0
-  resolution: "fast-uri@npm:3.1.0"
-  checksum: 44364adca566f70f40d1e9b772c923138d47efeac2ae9732a872baafd77061f26b097ba2f68f0892885ad177becd065520412b8ffeec34b16c99433c5b9e2de7
+  version: 3.1.2
+  resolution: "fast-uri@npm:3.1.2"
+  checksum: 8/73a6e1b04e6fcf7a09ed93316e72d643ef177d26969973784690708612141f2c2f74657120bab75bf5bbc26bfd535a32c90a8c3bc50aca50584cf01f98815afe
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2415,12 +2415,12 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.12
-  resolution: "brace-expansion@npm:1.1.12"
+  version: 1.1.15
+  resolution: "brace-expansion@npm:1.1.15"
   dependencies:
-    balanced-match: "npm:^1.0.0"
-    concat-map: "npm:0.0.1"
-  checksum: 975fecac2bb7758c062c20d0b3b6288c7cc895219ee25f0a64a9de662dbac981ff0b6e89909c3897c1f84fa353113a721923afdec5f8b2350255b097f12b1f73
+    balanced-match: ^1.0.0
+    concat-map: 0.0.1
+  checksum: 8/f2a950034e670523cc186da61aabe3beab74b1b8a7c74a756bf6b172dad1917312f255d9ec46906c9f0cab530868095d8c143918576930dd0e1323c3803850f1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,6 +16,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/code-frame@npm:7.29.7"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.29.7
+    js-tokens: ^4.0.0
+    picocolors: ^1.1.1
+  checksum: 8/21b12fe2356e36f6cc3cd8a3721f878bfeea80ce38356979a0518b47b3aafdcc0bd263da75ccc9d51c64d40b1b6df00e768ce2446acb0b7cbec0ae8f905663ad
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.20.5, @babel/compat-data@npm:^7.27.2, @babel/compat-data@npm:^7.27.7, @babel/compat-data@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/compat-data@npm:7.28.5"
@@ -56,6 +67,19 @@ __metadata:
     "@jridgewell/trace-mapping": "npm:^0.3.28"
     jsesc: "npm:^3.0.2"
   checksum: 9f219fe1d5431b6919f1a5c60db8d5d34fe546c0d8f5a8511b32f847569234ffc8032beb9e7404649a143f54e15224ecb53a3d11b6bb85c3203e573d91fca752
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/generator@npm:7.29.7"
+  dependencies:
+    "@babel/parser": ^7.29.7
+    "@babel/types": ^7.29.7
+    "@jridgewell/gen-mapping": ^0.3.12
+    "@jridgewell/trace-mapping": ^0.3.28
+    jsesc: ^3.0.2
+  checksum: 8/6bb8f4dc0641dca19e81f5daab37ed1a1f5a78e4d702eb79a4275739f773975134e250090c182cf1eea35d9bd65e634b9d9babf66600ffdcf8ac62fa40f3b980
   languageName: node
   linkType: hard
 
@@ -133,6 +157,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-globals@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-globals@npm:7.29.7"
+  checksum: 8/6deaf9846a415c7f110ac153e8c3d81e3543c9b685aa9fd9a59b4235f402e2b760129d3df49466daea9162f0cf73ff98a0ec7f180448a3449ca14ae5e1117b42
+  languageName: node
+  linkType: hard
+
 "@babel/helper-member-expression-to-functions@npm:^7.27.1, @babel/helper-member-expression-to-functions@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/helper-member-expression-to-functions@npm:7.28.5"
@@ -153,6 +184,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-imports@npm:7.29.7"
+  dependencies:
+    "@babel/traverse": ^7.29.7
+    "@babel/types": ^7.29.7
+  checksum: 8/ad5a768fc9c162620b7f5b7645c6c2efee1e6f9df432bb79651888661a7e4cd91dac7192f3ddcfd6de4778a089e9fb30fafae768156aa73a07eeca425f64e849
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.27.1, @babel/helper-module-transforms@npm:^7.28.3":
   version: 7.28.3
   resolution: "@babel/helper-module-transforms@npm:7.28.3"
@@ -163,6 +204,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 549be62515a6d50cd4cfefcab1b005c47f89bd9135a22d602ee6a5e3a01f27571868ada10b75b033569f24dc4a2bb8d04bfa05ee75c16da7ade2d0db1437fcdb
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-transforms@npm:7.29.7"
+  dependencies:
+    "@babel/helper-module-imports": ^7.29.7
+    "@babel/helper-validator-identifier": ^7.29.7
+    "@babel/traverse": ^7.29.7
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: 8/484f6d02975d304f680d44e331d4b832d67e51917483985eab7b853664452b5a627366e7a9d421200ec772a123213a591e28b40636566afeac189411ba3f45a8
   languageName: node
   linkType: hard
 
@@ -179,6 +233,13 @@ __metadata:
   version: 7.27.1
   resolution: "@babel/helper-plugin-utils@npm:7.27.1"
   checksum: 94cf22c81a0c11a09b197b41ab488d416ff62254ce13c57e62912c85700dc2e99e555225787a4099ff6bae7a1812d622c80fbaeda824b79baa10a6c5ac4cf69b
+  languageName: node
+  linkType: hard
+
+"@babel/helper-plugin-utils@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-plugin-utils@npm:7.29.7"
+  checksum: 8/b0a183abcc6670afa4861425fa428217d8ebadce062d5b43117919e8715f820080fd63bbfcf0e43c6e0e7d21a96b21f635c46dda80bdb0ce7e8a762ebee1d8d9
   languageName: node
   linkType: hard
 
@@ -225,10 +286,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-string-parser@npm:7.29.7"
+  checksum: 8/4c229d2c2296b6c94439e87ecddf3a93cee3ffd2d4cee0b4c28079275bed3de4e02cd943e4cb06036d1d9407549c4e3423006b61a46215c482fce902ee02bc0b
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.27.1, @babel/helper-validator-identifier@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/helper-validator-identifier@npm:7.28.5"
   checksum: 42aaebed91f739a41f3d80b72752d1f95fd7c72394e8e4bd7cdd88817e0774d80a432451bcba17c2c642c257c483bf1d409dd4548883429ea9493a3bc4ab0847
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: 8/cc7779e96fe9c9478c96ca4bf04fc338b95b501aa5abe78178307dea282d4a5dc23d443efb12dde8e8c5636d03dd00e443532e6ed7f15fa7977349af1f87ba4d
   languageName: node
   linkType: hard
 
@@ -268,6 +343,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 5bbe48bf2c79594ac02b490a41ffde7ef5aa22a9a88ad6bcc78432a6ba8a9d638d531d868bd1f104633f1f6bba9905746e15185b8276a3756c42b765d131b1ef
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/parser@npm:7.29.7"
+  dependencies:
+    "@babel/types": ^7.29.7
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 8/56f4c32a371004d3becd0a960a85a3bba4ec4df73d5e202aa3fe6473328b243162c6be9a510be1c12ed1825f5ce9ff1ea5cc357298631e8acf2e5b8da9f5a961
   languageName: node
   linkType: hard
 
@@ -707,16 +793,16 @@ __metadata:
   linkType: hard
 
 "@babel/plugin-transform-modules-systemjs@npm:^7.28.5":
-  version: 7.28.5
-  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.28.5"
+  version: 7.29.7
+  resolution: "@babel/plugin-transform-modules-systemjs@npm:7.29.7"
   dependencies:
-    "@babel/helper-module-transforms": "npm:^7.28.3"
-    "@babel/helper-plugin-utils": "npm:^7.27.1"
-    "@babel/helper-validator-identifier": "npm:^7.28.5"
-    "@babel/traverse": "npm:^7.28.5"
+    "@babel/helper-module-transforms": ^7.29.7
+    "@babel/helper-plugin-utils": ^7.29.7
+    "@babel/helper-validator-identifier": ^7.29.7
+    "@babel/traverse": ^7.29.7
   peerDependencies:
     "@babel/core": ^7.0.0-0
-  checksum: 7e8c0bcff79689702b974f6a0fedb5d0c6eeb5a5e3384deb7028e7cfe92a5242cc80e981e9c1817aad29f2ecc01841753365dd38d877aa0b91737ceec2acfd07
+  checksum: 8/185d26d1f20fabdb120cb0bacdb2d245a8fbe628778cc2cd096a804c1169e21ae555e482b76fcc04a585edd70d9758a456794ae4d69cd41e638e10f620d65058
   languageName: node
   linkType: hard
 
@@ -1138,6 +1224,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/template@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": ^7.29.7
+    "@babel/parser": ^7.29.7
+    "@babel/types": ^7.29.7
+  checksum: 8/521eb6a1fd4735074ca8dac0d70810860a80edf3bf78105851571993cd13701a2041987e7398ccc9376eb6235ea1258bf494ccaccf3b67fa98dbe954154a2e93
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.27.1, @babel/traverse@npm:^7.28.0, @babel/traverse@npm:^7.28.3, @babel/traverse@npm:^7.28.4, @babel/traverse@npm:^7.28.5":
   version: 7.28.5
   resolution: "@babel/traverse@npm:7.28.5"
@@ -1153,6 +1250,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/traverse@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": ^7.29.7
+    "@babel/generator": ^7.29.7
+    "@babel/helper-globals": ^7.29.7
+    "@babel/parser": ^7.29.7
+    "@babel/template": ^7.29.7
+    "@babel/types": ^7.29.7
+    debug: ^4.3.1
+  checksum: 8/6c4508fd2a308a6a41fbf40bd2590bccfdc3903de51c640a928c49e810220b9e27323a083cda604d44a27449b57265a701b549de01f479611390863734b4fd38
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.27.1, @babel/types@npm:^7.27.3, @babel/types@npm:^7.28.2, @babel/types@npm:^7.28.4, @babel/types@npm:^7.28.5, @babel/types@npm:^7.4.4":
   version: 7.28.5
   resolution: "@babel/types@npm:7.28.5"
@@ -1160,6 +1272,16 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
   checksum: a5a483d2100befbf125793640dec26b90b95fd233a94c19573325898a5ce1e52cdfa96e495c7dcc31b5eca5b66ce3e6d4a0f5a4a62daec271455959f208ab08a
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/types@npm:7.29.7"
+  dependencies:
+    "@babel/helper-string-parser": ^7.29.7
+    "@babel/helper-validator-identifier": ^7.29.7
+  checksum: 8/71c46837d22c5c63a5ed571f3b68b4261ecabfc3d4be7251b336ccbd26bc52752ae68ae6d16d24ea512311b78b6f54efdfb00dde87a81a4dc3d19e4a45f05b20
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5385,9 +5385,9 @@ __metadata:
   linkType: hard
 
 "node-forge@npm:^1":
-  version: 1.3.2
-  resolution: "node-forge@npm:1.3.2"
-  checksum: 1def35652c93a588718a6d0d0b4f33e3e7de283aa6f4c00d01d1605d6ccce23fb3b59bcbfb6434014acd23a251cfcc2736052b406f53d94e1b19c09d289d0176
+  version: 1.4.0
+  resolution: "node-forge@npm:1.4.0"
+  checksum: 8/c97c634d4d483aae815677db5b1bd14bfea4d873ab48817e020610a2b4d8bc6b3e77994860189b44151ff8e0842c0c4ba6faa80b9a6e6fbd6989865e8eb80b96
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5328,12 +5328,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
+"nanoid@npm:^3.3.12":
+  version: 3.3.15
+  resolution: "nanoid@npm:3.3.15"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 40e7f70b3d15f725ca072dfc4f74e81fcf1fbb02e491cf58ac0c79093adc9b0a73b152bcde57df4b79cd097e13023d7504acb38404a4da7bc1cd8e887b82fe0b
+  checksum: 8/0f645685aefba48aae06acfb390be660041d91b4ec63d85544ed01b619c6d661c985170bfbcd29b7265b6c1c3369c631e5dcb2f34c34e2c0023108bc158531d1
   languageName: node
   linkType: hard
 
@@ -6236,13 +6236,13 @@ __metadata:
   linkType: hard
 
 "postcss@npm:^8.2.14, postcss@npm:^8.2.15":
-  version: 8.5.6
-  resolution: "postcss@npm:8.5.6"
+  version: 8.5.15
+  resolution: "postcss@npm:8.5.15"
   dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 5127cc7c91ed7a133a1b7318012d8bfa112da9ef092dddf369ae699a1f10ebbd89b1b9f25f3228795b84585c72aabd5ced5fc11f2ba467eedf7b081a66fad024
+    nanoid: ^3.3.12
+    picocolors: ^1.1.1
+    source-map-js: ^1.2.1
+  checksum: 8/82e046d5bd0c537e7bcae1b97ec366968cac4ebdbd38773b69a2a4ad437f26641643a48f120317dd167199ac718ff8a0ab7dd102258430e4c919daaef0e57904
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3902,12 +3902,12 @@ __metadata:
   linkType: hard
 
 "follow-redirects@npm:^1.0.0":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
+  checksum: 8/e90dce4607b1f6b8b9883287f912585573c19088209ad82341d550a795b4ba514522b73b1b340cf618279df27975cd46504d09149be60291ba6767384c1fd8f8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Merged all open dependabot pr's
- Rewrote readme.md: fixed badge URL typo, added requirements table (Laravel 10–13 / PHP 8.0+), restructured installation steps, synced config block with actual config file, and consolidated all Filament integration docs into one dedicated section
- Updated docs/google-tag-manager.md: added GA4 deprecation notice and updated Step 3 to reference GA4 tag types instead of the sunset Universal Analytics